### PR TITLE
Add method to rotate a relative location around a location in the world.

### DIFF
--- a/src/me/libraryaddict/holograms/Hologram.java
+++ b/src/me/libraryaddict/holograms/Hologram.java
@@ -320,7 +320,8 @@ public class Hologram {
         if (entity != null) {
             this.keepAliveAfterEntityDies = isRemoveOnEntityDeath;
             relativeToEntity = getLocation().subtract(entity.getLocation());
-            entityLastLocation = entity.getLocation();
+            entityLastLocation = new Location(entity.getWorld(), 0, 0, 0); // Set this to zero so it is forced to update the location.
+            //entityLastLocation = entity.getLocation();
             Location l = entity.getLocation();
             if (setRelativeYaw || setRelativePitch) {
                 relativeToEntity.setPitch(l.getPitch());

--- a/src/me/libraryaddict/holograms/Hologram.java
+++ b/src/me/libraryaddict/holograms/Hologram.java
@@ -58,6 +58,7 @@ public class Hologram {
     private boolean setRelativePitch;
     private boolean setRelativeYaw;
     private int viewDistance = 70;
+    private double maxYDiff= 30;
 
     public Hologram(Location location, String... lines) {
         assert lines.length != 0 : "You need more lines than nothing!";
@@ -151,6 +152,10 @@ public class Hologram {
     boolean isVisible(Player player, Location loc) {
         return (getTarget() == HologramTarget.BLACKLIST != hasPlayer(player)) && loc.getWorld() == getLocation().getWorld()
                 && (loc.distance(getLocation()) <= viewDistance);
+    }
+
+    public double getMaxYDiff() {
+        return maxYDiff;
     }
 
     private void makeDestroyPacket() {
@@ -456,6 +461,11 @@ public class Hologram {
 
     public Hologram setVector(Vector vector) {
         this.moveVector = vector;
+        return this;
+    }
+
+    public Hologram setMaxYDiff(double max) {
+        this.maxYDiff = max;
         return this;
     }
 

--- a/src/me/libraryaddict/holograms/HologramCentral.java
+++ b/src/me/libraryaddict/holograms/HologramCentral.java
@@ -53,14 +53,13 @@ public class HologramCentral implements Listener {
                                 Location relativeLocation = hologram.getRelativeToEntity();
                                 if (hologram.isRelativePitch() || hologram.isRelativeYaw()) {
                                     if (hologram.isRelativePitchControlMoreThanHeight()) {
-                                        // TODO Calculate new height based on how high the entity is looking.
-                                        // The max height difference can be 30 for now.
-                                        // TODO Calculate new X Z as a circle around the player
-
-                                        // Rotate the relative location around the entity location using yaw only?????
+                                        // Rotate the relative location around the entity location using yaw only.
                                         Location rotatedLocation = rotateLocation(entityLocation, relativeLocation, entityLocation.getYaw(), 0);
-                                        // Do something to the Y?, Im not sure what you wanted here.
-                                        //rotatedLocation.setY();
+                                        // Set the Y using pitch and relative distance.
+                                        double yDiff = Math.tan(Math.toRadians(-entityLocation.getPitch())) * Math.sqrt(relativeLocation.getX() * relativeLocation.getX() + relativeLocation.getZ() * relativeLocation.getZ());
+                                        int neg = yDiff >= 0 ? 1 : -1;
+                                        rotatedLocation.setY(entityLocation.getY() + relativeLocation.getY() + neg * Math.min(Math.abs(yDiff), hologram.getMaxYDiff()));
+
                                         hologram.moveHologram(rotatedLocation, false);
                                     } else {
                                         // Rotate the relative location around the entity location using the pitch and yaw.


### PR DESCRIPTION
Use method for entity follow, still requires some tweaks and additions.

On line 67 do you want for example only the yaw to be used if hologram.isRelativePitch() is false and vice versa?
Also not sure what isRelativePitchControlMoreThanHeight is supposed to do so I just added some temp code in there.

Here is the plugin I used to test it:

``` Java
    @Override
    public void onEnable() {
        getServer().getPluginManager().registerEvents(this, this);
    }

    @EventHandler
    public void onJoin(PlayerJoinEvent event) {
        // X = Right(Neg) - Left(Pos)
        // Y = Up(Pos) - Down(Neg)
        // Z = Behind entity(Neg) - In front entity(Pos).
        new Hologram(event.getPlayer().getEyeLocation()
                .add(0, 0, 6), ChatColor.GOLD + "This is a hologram",
                ChatColor.RED + "Center").setFollowEntity(event.getPlayer(), false, true, true, false)
                .start();

        new Hologram(event.getPlayer().getEyeLocation()
                .add(0, 2, 6), ChatColor.GOLD + "Top").setFollowEntity(event.getPlayer(), false, true, true, false)
                .start();

        new Hologram(event.getPlayer().getEyeLocation()
                .add(0, -2, 6), ChatColor.GOLD + "Bottom").setFollowEntity(event.getPlayer(), false, true, true, false)
                .start();

        new Hologram(event.getPlayer().getEyeLocation()
                .add(-3, 0, 6), ChatColor.GOLD + "Right").setFollowEntity(event.getPlayer(), false, true, true, false)
                .start();

        new Hologram(event.getPlayer().getEyeLocation()
                .add(3, 0, 6), ChatColor.GOLD + "Left").setFollowEntity(event.getPlayer(), false, true, true, false)
                .start();
    }
```
